### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.github/workflows/dotnet-cd.yml
+++ b/.github/workflows/dotnet-cd.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 10.0.x
     - name: Run tests
       env:
         TEST_REAL_API: true
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 10.0.x
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.2
@@ -75,7 +75,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 10.0.x
     - name: Push Package to GitHub
       run: dotnet nuget push --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/hughesjs/index.json" --skip-duplicate *.nupkg
 
@@ -94,7 +94,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 10.0.x
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       id: login

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 10.0.x
     - name: Run tests
       env:
         SpaceTrackSdkOptions__Password: ${{ secrets.SPACE_TRACK_PASSWORD }}

--- a/src/SpaceTrackSdk.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/SpaceTrackSdk.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -13,7 +13,13 @@ public class ServiceCollectionExtensionsTests
 	public ServiceCollectionExtensionsTests()
 	{
 		IConfigurationBuilder configBuilder = new ConfigurationBuilder();
-		configBuilder.AddEnvironmentVariables();
+		configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+		{
+			["SpaceTrackSdkOptions:Username"]     = "stub",
+			["SpaceTrackSdkOptions:Password"]     = "stub",
+			["SpaceTrackSdkOptions:ApiUrl"]       = "http://stub.local",
+			["SpaceTrackSdkOptions:AuthEndpoint"] = "/ajaxauth/login",
+		});
 		IConfigurationRoot config = configBuilder.Build();
 		
 		ServiceCollection services = new();

--- a/src/SpaceTrackSdk.Tests/Fixtures/ClientTestFixture.cs
+++ b/src/SpaceTrackSdk.Tests/Fixtures/ClientTestFixture.cs
@@ -25,6 +25,16 @@ public class ClientTestFixture
 		
 		IConfigurationBuilder configBuilder = new ConfigurationBuilder();
 		configBuilder.AddEnvironmentVariables();
+		if (!useRealApi)
+		{
+			configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["SpaceTrackSdkOptions:Username"]     = "stub",
+				["SpaceTrackSdkOptions:Password"]     = "stub",
+				["SpaceTrackSdkOptions:ApiUrl"]       = "http://stub.local",
+				["SpaceTrackSdkOptions:AuthEndpoint"] = "/ajaxauth/login",
+			});
+		}
 		IConfigurationRoot config = configBuilder.Build();
 		
 		ServiceCollection services = new();

--- a/src/SpaceTrackSdk.Tests/SpaceTrackSdk.Tests.csproj
+++ b/src/SpaceTrackSdk.Tests/SpaceTrackSdk.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -11,20 +11,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.0" />
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
+        <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.6.6" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/SpaceTrackSdk/Public/Queries/Operators/Operator.cs
+++ b/src/SpaceTrackSdk/Public/Queries/Operators/Operator.cs
@@ -18,7 +18,7 @@ public abstract class Operator<T>: IQueryOperator
 	{
 		IQueryOperator? component = Value as IQueryOperator;
 
-		string? value = Value.ToString();
+		string? value = Value?.ToString();
 		if (component is not null)
 		{
 			value = component.GetQueryString();

--- a/src/SpaceTrackSdk/SpaceTrackSdk.csproj
+++ b/src/SpaceTrackSdk/SpaceTrackSdk.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>0.0.1</Version>
         <PackageProjectUrl>https://github.com/hughesjs/SpaceTrackSdk</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/hughesjs/SpaceTrackSdk/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>AGPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/hughesjs/SpaceTrackSdk.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>
@@ -18,16 +18,16 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="ArchonAnalysers" Version="0.3.0">
+      <PackageReference Include="ArchonAnalysers" Version="0.4.0">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+      <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Framework upgrade from `net7.0` (out of support) to `net10.0` (current), aligning package versions with the new runtime.

## Changes

- `TargetFramework` bumped to `net10.0` in library and tests
- `Microsoft.Extensions.*` packages aligned at `10.0.6`
- Test framework packages bumped (xunit 2.9.3, Microsoft.NET.Test.Sdk 18.4.0, coverlet 10.0.0)
- CI/CD workflows updated to `dotnet-version: 10.0.x`
- Deprecated `PackageLicenseUrl` replaced with `PackageLicenseExpression` (`AGPL-3.0-only`)
- Fixed CS8602 null-dereference in `Operator<T>.GetQueryString` (`Value.ToString()` → `Value?.ToString()`)
- Test fixtures now inject stub configuration so the suite runs without real SpaceTrack credentials

## Test plan

- [ ] CI builds cleanly with `-warnaserror`
- [ ] All 205 tests pass against the stubbed HTTP handler
- [ ] Live tests still work when `TEST_REAL_API` env var is set (unchanged code path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded project target framework to .NET 10.0.
  * Updated CI/CD pipelines to use .NET SDK 10.0.x.
  * Updated NuGet dependencies and test packages to latest compatible versions.
  * Updated licence metadata to AGPL-3.0-only.

* **Bug Fixes**
  * Fixed potential null reference exception in query operator value conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->